### PR TITLE
Initial support of AVIA model

### DIFF
--- a/openpylivox/openpylivox.py
+++ b/openpylivox/openpylivox.py
@@ -1376,7 +1376,7 @@ class _dataCaptureThread(object):
                 if self._showMessages:
                     print("   " + self.sensorIP + self._format_spaces + "   -->     closed BINARY file: " + self.filePathAndName)
                     print("                                (points: " + str(numPts) + " good, " + str(nullPts) + " null, " + str(numPts + nullPts) + " total)")
-                    if self._deviceType == "Horizon" or self._deviceType == "Tele-15":
+                    if self._deviceType in ["Horizon", "Tele-15", "AVIA"]:
                         print("                                (IMU records: " + str(imu_records) + ")")
 
                 binFile.close()
@@ -1814,6 +1814,8 @@ class openpylivox(object):
                     typeMessage = "Tele-15"
                 elif device_type == 3:
                     typeMessage = "Horizon"
+                elif device_type == 7:
+                    typeMessage = "AVIA"
                 else:
                     typeMessage = "UNKNOWN"
 


### PR DESCRIPTION
Current change introduces basic support of "AVIA" Livox lidar.
relates to #24 

PS. Device type was taken from [Livox SDK](https://github.com/Livox-SDK/Livox-SDK/blob/05cc408e54bce90863cd4f160992a92ddea1fd29/sdk_core/include/livox_def.h#L39)